### PR TITLE
Add improved styling for the contact page

### DIFF
--- a/css/contact.styles.css
+++ b/css/contact.styles.css
@@ -120,12 +120,12 @@ header .active .item {
 }
 main {
   width: 100%;
-  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
 }
 main .container {
+  margin: 3rem auto;
   width: 80%;
   display: flex;
   flex-wrap: wrap;
@@ -202,6 +202,11 @@ main .container .form form input[type=submit] {
     justify-content: center;
     align-items: center;
     border: none;
+  }
+}
+@media (min-width: 968px) {
+  main .container {
+    margin: 5rem auto;
   }
 }
 footer {

--- a/js/validate.js
+++ b/js/validate.js
@@ -45,5 +45,8 @@ $('#contact-form').validate({
             required: 'Please let me know the subject of your message.',
             minlength: 'Please make your subject at least 3 characters.'
         },
+        message: {
+            required: 'Please leave me a message!'
+        }
     }
 });

--- a/less/contact.styles.less
+++ b/less/contact.styles.less
@@ -149,12 +149,13 @@ header {
 //Main section styling
 main {
     width: 100%;
-    height: 100%;
+    //height: 100%;
     display: flex;
     justify-content: center;
     align-items: center;
 
     .container {
+        margin: 3rem auto;
         width: 80%;
         display: flex;
         flex-wrap: wrap;
@@ -237,6 +238,10 @@ main {
                 align-items: center;
                 border: none;
             }
+        }
+
+        @media (min-width: 968px) {
+            margin: 5rem auto;
         }
     }
 }


### PR DESCRIPTION
I improved the styling to the contact page that prevents the container from hanging over the header and footer sections when error messages are displayed on the contact form.